### PR TITLE
Modify handling of coordinate transformation matrix operator

### DIFF
--- a/python/process_content.py
+++ b/python/process_content.py
@@ -243,8 +243,11 @@ def processImage(lines):
         elif op == "re":
             rect = np.array(s[:-1], dtype = float)
         elif op == "cm":
-            ctm = np.array(s[:-1], dtype = float)
-            print("[IMG] ctm:", ctm)
+            try:
+                ctm = np.array(s[-7:-1], dtype = float)
+                print("[IMG] ctm:", ctm)
+            except ValueError as e:
+                print("Error setting CTM from", s, ": ", e)
         elif op == "Q":
             if s[-2] == "Do":
                 name = s[-3]


### PR DESCRIPTION
Set CTM parameters from the last six elements of the array preceding
the `cm` operator. This adjustment is to handle cases where the operator
does not appear on a separate line but includes other operators and parameters.